### PR TITLE
Couple of small edits so things run more smoothly

### DIFF
--- a/Rev/README.md
+++ b/Rev/README.md
@@ -2,7 +2,7 @@ This folder contains everything needed to run RevBayes analyses of the 2013 biso
 
 For stability, these can all be run with the development branch of the fork of Rev available at: https://github.com/afmagee/revbayes/
 
-#Installation of the fork of Revbayes
+# Installation of the fork of Revbayes
 
 Installing RevBayes on linux/Mac requires Cmake and a C++ compiler. With these in place, the process should be as easy as:
     
@@ -11,16 +11,16 @@ Installing RevBayes on linux/Mac requires Cmake and a C++ compiler. With these i
 
 There are further instructions available [here](http://revbayes.github.io/software.html) for linux/Mac, and in revbayes/projects/RevBayes\_Win\_Installation\_Instruction.txt for windows users. If using these instructions, be sure to clone from https://github.com/afmagee/revbayes.git and not https://github.com/revbayes/revbayes.git.
 
-#Running analyses
+# Running analyses
 
 To run any tests or analyses, Rev should be compiled from this source, and called from the top level of /analyses or /tests as appropriate.
 
-###Running analyses of Bison data
+### Running analyses of Bison data
     
     1. Generate analysis scripts by opening R in the Rev folder and sourcing "/analyses/setup/generate_analysis_scripts.R". The number of replicates and seed are set here
     2. Call RevBayes from Rev/analyses on the scripts in Rev/analyses/src, output will be printed to Rev/analyses/output
     
-###Running analyses of simulated data
+### Running analyses of simulated data
 There are two sets of analyses here, fixed-tree analyses of only the coalescent model (in /tree\_only) and joint analyses (coalescent model and tree, in /full\_model).
 Start by generating the necessary scripts for Rev then source the scripts in Rev:
 
@@ -36,7 +36,7 @@ Note that the following steps were already taken to produce the necessary data f
     4. Simulated alignments on subsampled trees to test joint inference (Rev/tests/setup/sim_seqs.Rev)
 
 
-#File structure
+# File structure
     
     /analyses contains the requisite scripts and files for analyzing the data
     

--- a/Rev/analyses/setup/GMRF_bison_template.Rev
+++ b/Rev/analyses/setup/GMRF_bison_template.Rev
@@ -172,7 +172,7 @@ mymodel = model(Ne)
 ### Run 80 million iterations thinned at every 64 thousand, which gives 1250 samples to keep for this chain (run 4 chains)
 ## Start with 1 million of burnin
 mni = 0
-monitors[++mni] = mnModel(filename="output/bison_skygrid_fixed_clock_THISREP.log",printgen=64000, separator = TAB,zlog_Ne1, delta_logNe, logNe, gamma_cats, gamma_shape, kappa,pi, sig, RA, TL)
+monitors[++mni] = mnModel(filename="output/bison_skygrid_fixed_clock_THISREP.log",printgen=64000, separator = TAB)
 monitors[++mni] = mnFile(filename="output/bison_skygrid_THISREP.trees",printgen=64000, separator = TAB, psi)
 monitors[++mni] = mnScreen(printgen=64000, logNe[1],logNe[50],logNe[99],sig)
 

--- a/Rev/analyses/setup/HSRF_bison_template.Rev
+++ b/Rev/analyses/setup/HSRF_bison_template.Rev
@@ -169,8 +169,7 @@ mymodel = model(Ne)
 ### Run 80 million iterations thinned at every 64 thousand, which gives 1250 samples to keep for this chain (run 4 chains)
 ## Start with 1 million of burnin
 mni = 0
-monitors[++mni] = mnModel(filename="output/bison_horseshoe_skygrid_fixed_clock_THISREP.log",printgen=64000, separator = TAB, 
-			zlog_Ne1, delta_logNe, logNe, sigma, gamma, gamma_cats, gamma_shape, kappa,pi,  RA, TL)
+monitors[++mni] = mnModel(filename="output/bison_horseshoe_skygrid_fixed_clock_THISREP.log",printgen=64000, separator = TAB)
 monitors[++mni] = mnFile(filename="output/bison_horseshoe_skygrid_THISREP.trees",printgen=64000, separator = TAB, psi)
 monitors[++mni] = mnScreen(printgen=64000,logNe[1], logNe[50], logNe[99],gamma)
 

--- a/Rev/analyses/setup/generate_analysis_scripts.R
+++ b/Rev/analyses/setup/generate_analysis_scripts.R
@@ -7,6 +7,7 @@ GMRF_template <- readLines("analyses/setup/GMRF_bison_template.Rev")
 HSRF_template <- readLines("analyses/setup/HSRF_bison_template.Rev")
 
 seed <- first_seed
+dir.create("analyses/src", recursive=TRUE, showWarnings=FALSE)
 
 # Generate GMRF analysis files
 for (i in 1:n_replicate_analyses) {

--- a/Rev/tests/setup/generate_test_scripts.R
+++ b/Rev/tests/setup/generate_test_scripts.R
@@ -16,6 +16,7 @@ GMRF_template <- readLines("tests/setup/test_GMRF_bison_template.Rev")
 HSRF_template <- readLines("tests/setup/test_HSRF_bison_template.Rev")
 
 seed <- first_seed
+dir.create("tests/full_model/src", recursive=TRUE, showWarnings=FALSE)
 
 for (d in 1:4) {
   DS <- datasets[d]
@@ -50,6 +51,8 @@ for (d in 1:4) {
 
 GMRF_template <- readLines("tests/setup/test_GMRF_tree_only_template.Rev")
 HSRF_template <- readLines("tests/setup/test_HSRF_tree_only_template.Rev")
+
+dir.create("tests/tree_only/src", recursive=TRUE, showWarnings=FALSE)
 
 for (d in 1:4) {
   DS <- datasets[d]


### PR DESCRIPTION
- Fix formatting on README (Github flavoured markdown seems quite picky)
- Make R-scripts create output directories, without that scripts either crash or don't create output files
- Fix mnModel commands in analyses/ RevBayes templates. Seems to have had too many parameters which didn't run in RevBayes. Deleting extra parameters seems to work.
